### PR TITLE
Quit application with back button

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -234,8 +234,21 @@ Kirigami.ApplicationWindow {
 
         WelcomePage {
             onBackRequested: {
+                if (!BTConnectionManager.isConnected) {
+                    return;
+                }
+
                 event.accepted = true;
-                Qt.quit();
+
+                showMessageBox(qsTr("A tail is currently connected"),
+                               qsTr("A tail is currently connected.\n\nAre you sure that you want to disconnect from the tail and quit?"),
+                               function () {
+                                   if(BTConnectionManager.isConnected) {
+                                       BTConnectionManager.disconnectDevice();
+                                   }
+
+                                   Qt.quit();
+                               });
             }
         }
     }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -231,7 +231,13 @@ Kirigami.ApplicationWindow {
     }
     Component {
         id: welcomePage;
-        WelcomePage {}
+
+        WelcomePage {
+            onBackRequested: {
+                event.accepted = true;
+                Qt.quit();
+            }
+        }
     }
     Component {
         id: alarmList;


### PR DESCRIPTION
Quit the app when a user tap to back button when `Welcome` page is active.
Should be tested on Android device.
And later we should add `Toast` to show message something like this: "To quit the app tap back button again".
