### PR TITLE
Fix playing audio at Glash button

### DIFF
--- a/src/qml/DeveloperModePage.qml
+++ b/src/qml/DeveloperModePage.qml
@@ -35,7 +35,7 @@ Kirigami.ScrollablePage {
 
             Layout.fillWidth: true;
 
-            SoundEffect {
+            Audio {
                 id: playSound
                 source: "qrc:/audio/Sparkle-sound-effect.mp3"
             }


### PR DESCRIPTION
We have to use `Audio` control instead of `SoundEffect`.