### PR TITLE
Remove using QSettings from BTDeviceModel

### DIFF
--- a/src/BTConnectionManager.cpp
+++ b/src/BTConnectionManager.cpp
@@ -30,8 +30,9 @@
 
 class BTConnectionManager::Private {
 public:
-    Private()
-        : tailStateCharacteristicUuid(QLatin1String("{0000ffe1-0000-1000-8000-00805f9b34fb}"))
+    Private(AppSettings* appSettings)
+        : appSettings(appSettings),
+          tailStateCharacteristicUuid(QLatin1String("{0000ffe1-0000-1000-8000-00805f9b34fb}"))
     {
     }
     ~Private() {}
@@ -71,9 +72,9 @@ public:
     int localBTDeviceState = 0;
 };
 
-BTConnectionManager::BTConnectionManager(QObject* parent)
+BTConnectionManager::BTConnectionManager(AppSettings* appSettings, QObject* parent)
     : BTConnectionManagerProxySource(parent)
-    , d(new Private)
+    , d(new Private(appSettings))
 {
     d->commandModel = new TailCommandModel(this);
 
@@ -86,6 +87,7 @@ BTConnectionManager::BTConnectionManager(QObject* parent)
             this, [this](){ emit commandQueueCountChanged(d->commandQueue->count()); });
 
     d->deviceModel = new BTDeviceModel(this);
+    d->deviceModel->setAppSettings(d->appSettings);
 
     connect(d->deviceModel, &BTDeviceModel::countChanged,
             this, [this](){ emit deviceCountChanged(d->deviceModel->count()); });
@@ -130,6 +132,7 @@ AppSettings* BTConnectionManager::appSettings() const
 void BTConnectionManager::setAppSettings(AppSettings* appSettings)
 {
     d->appSettings = appSettings;
+    d->deviceModel->setAppSettings(d->appSettings);
 }
 
 void BTConnectionManager::setLocalBTDeviceState()

--- a/src/BTConnectionManager.h
+++ b/src/BTConnectionManager.h
@@ -39,7 +39,7 @@ class BTConnectionManager : public BTConnectionManagerProxySource
     Q_PROPERTY(QObject* commandQueue READ commandQueue NOTIFY commandQueueChanged)
 
 public:
-    explicit BTConnectionManager(QObject* parent = nullptr);
+    explicit BTConnectionManager(AppSettings* appSettings, QObject* parent);
     virtual ~BTConnectionManager();
 
     AppSettings* appSettings() const;

--- a/src/BTDeviceModel.cpp
+++ b/src/BTDeviceModel.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "BTDeviceModel.h"
-#include <QSettings>
+#include "AppSettings.h"
 
 class BTDeviceModel::Private
 {
@@ -29,6 +29,7 @@ public:
 
     void readDeviceNames();
 
+    AppSettings* appSettings = nullptr;
     QList<BTDeviceModel::Device*> devices;
     QMap<QString, QString> deviceNames;
 };
@@ -46,14 +47,28 @@ BTDeviceModel::~BTDeviceModel()
 
 void BTDeviceModel::Private::readDeviceNames()
 {
-    deviceNames.clear();
-    QSettings settings;
-    settings.beginGroup("DeviceNameList");
-    QStringList keys = settings.childKeys();
-    foreach(QString key, keys) {
-        deviceNames[key] = settings.value(key).toString();
+    if (!appSettings) {
+        return;
     }
-    settings.endGroup();
+
+    deviceNames.clear();
+
+    const QVariantMap map = appSettings->deviceNames();
+
+    for (QVariantMap::const_iterator it = map.cbegin(); it != map.cend(); ++it) {
+        deviceNames[it.key()] = it.value().toString();
+    }
+}
+
+AppSettings *BTDeviceModel::appSettings() const
+{
+    return d->appSettings;
+}
+
+void BTDeviceModel::setAppSettings(AppSettings *appSettings)
+{
+    d->appSettings = appSettings;
+    d->readDeviceNames();
 }
 
 QHash< int, QByteArray > BTDeviceModel::roleNames() const

--- a/src/BTDeviceModel.h
+++ b/src/BTDeviceModel.h
@@ -22,6 +22,8 @@
 #include <QBluetoothDeviceInfo>
 #include <QBluetoothAddress>
 
+class AppSettings;
+
 class BTDeviceModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -46,6 +48,9 @@ public:
         QString deviceID;
         QBluetoothDeviceInfo deviceInfo;
     };
+
+    AppSettings* appSettings() const;
+    void setAppSettings(AppSettings* appSettings);
 
     QHash< int, QByteArray > roleNames() const override;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,8 +189,7 @@ int serviceMain(int argc, char *argv[])
     AppSettings* appSettings = new AppSettings(&app);
 
     qDebug() << "Creating connection manager";
-    BTConnectionManager* btConnectionManager = new BTConnectionManager(&app);
-    btConnectionManager->setAppSettings(appSettings);
+    BTConnectionManager* btConnectionManager = new BTConnectionManager(appSettings, &app);
     appSettings->alarmListImpl()->setCommandQueue(qobject_cast<CommandQueue*>(btConnectionManager->commandQueue()));
 
     QObject::connect(btConnectionManager, &BTConnectionManager::isConnectedChanged, [](bool isConnected) {


### PR DESCRIPTION
We should use `QSettings` only at the `AppSettings` class.